### PR TITLE
Update get_payload to decode the Content-Transfer-Encoding header

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,7 +72,7 @@ def emailParser(raw_email):
         msg_body = ""
         for part in msg.walk():
             if part.get_content_type() == 'text/plain':
-                msg_body = part.get_payload()
+                msg_body = part.get_payload(decode=True)
         slackWebHook(msg_subject,msg_from,date_epoch,msg_date,msg_body)
 
 def slackWebHook(subject, email_from, date_epoch,date_header, body):


### PR DESCRIPTION
Addresses some issues in #2.

This will decode the message payload if it's in `base64` or `quoted-printable` as the `Content-Transfer-Encoding` header.

So with these changes, this message with a `quoted-printable` Content-Transfer-Encoding header:

```
Hello world, =0A=0AIf Lorem ipsum dolor sit amet, consectetur=
adipiscing elit. Donec vel ex egestas ante scelerisque vulputate eget et me=
us. =0A=0A In non sollicitudin nulla,=
accumsan vehicula velit=
```

Will now be output as this:

```
Hello world, Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vel ex egestas ante scelerisque vulputate eget et metus. In non sollicitudin nulla, accumsan vehicula velit.
```

[See `get_payload` documentation for details on using `decode=True`](https://docs.python.org/2/library/email.message.html#email.message.Message.get_payload).

